### PR TITLE
Add null check to function isSetParameters

### DIFF
--- a/src/MarketplaceWebService/Model/ContentType.php
+++ b/src/MarketplaceWebService/Model/ContentType.php
@@ -76,7 +76,7 @@ class MarketplaceWebService_Model_ContentType extends MarketplaceWebService_Mode
 
     public function isSetParameters()
     {
-        return count($this->fields['Parameters']['FieldValue']) > 0;
+        return isset($this->fields['Parameters']['FieldValue']) && (count($this->fields['Parameters']['FieldValue']) > 0);
     }
 
     public function toString()


### PR DESCRIPTION
If isSetParameters is called before setParameters
$this->fields['Parameters']['FieldValue'] is still null, which triggers a warning in PHP 7 and an error in PHP 8.